### PR TITLE
Fix FXML and CSS that was parsed incorrectly on Ubuntu

### DIFF
--- a/src/main/resources/view/Components.css
+++ b/src/main/resources/view/Components.css
@@ -9,7 +9,7 @@
 
  .label {
     -fx-font-size: 11pt;
-    -fx-font-family: "Segoe UI";
+    -fx-font-family: "Noto Sans CJK SC Regular", "Segoe UI", sans-serif;
     -fx-text-fill: #404040;
 }
 
@@ -124,7 +124,8 @@
 
 .table-view .column-header .label {
     -fx-font-size: 20pt;
-    -fx-font-family: "Segoe UI Light";
+    -fx-font-family: "Noto Sans CJK SC Regular", "Segoe UI", sans-serif;
+    -fx-font-weight: bold;
     -fx-text-fill: white;
     -fx-alignment: center-left;
     -fx-opacity: 1;
@@ -146,7 +147,8 @@
     -fx-border-width: 2;
     -fx-background-radius: 0;
     -fx-background-color: #b0b0b0;
-    -fx-font-family: "Segoe UI", Helvetica, Arial, sans-serif;
+    -fx-font-family: "Noto Sans CJK SC Regular", "Segoe UI", sans-serif;
+    -fx-font-weight: bold;
     -fx-font-size: 11pt;
     -fx-text-fill: #404040;
     -fx-background-insets: 0 0 0 0, 0, 1, 2;

--- a/src/main/resources/view/LightTheme.css
+++ b/src/main/resources/view/LightTheme.css
@@ -12,7 +12,7 @@
     -fx-border-color: #c0c0c0;
     -fx-border-radius: 4px;
     -fx-border-width: 1;
-    -fx-font-family: "Segoe UI";
+    -fx-font-family: "Noto Sans CJK SC Regular", "Segoe UI", sans-serif;
     -fx-font-size: 11pt;
     -fx-text-fill: black;
 }
@@ -28,7 +28,7 @@
     -fx-border-color: #c0c0c0;
     -fx-border-radius: 4px;
     -fx-border-width: 1;
-    -fx-font-family: "Segoe UI Light";
+    -fx-font-family: "Noto Sans CJK SC Light", "Segoe UI Light", sans-serif;
     -fx-font-size: 10pt;
     -fx-text-fill: black;
     -fx-highlight-fill: lightblue;
@@ -59,13 +59,6 @@
     -fx-border-width: 1;
 }
 
-.content-entry-list .label {
-    -fx-font-family: "Segoe UI Light";
-    -fx-font-size: 12pt;
-    -fx-text-fill: black;
-    -fx-highlight-fill: lightblue;
-}
-
 .card-pane {
     -fx-padding: 8;
     -fx-background-color: transparent;
@@ -73,14 +66,14 @@
 }
 
 .content-display .card-large-label {
-    -fx-font-family: "Segoe UI";
+    -fx-font-family: "Noto Sans CJK SC Black", "Segoe UI", sans-serif;
     -fx-font-weight: bolder;
     -fx-font-size: 14px;
     -fx-text-fill: black;
 }
 
 .content-display .card-label {
-    -fx-font-family: "Segoe UI";
+    -fx-font-family: "Noto Sans CJK SC Regular", "Segoe UI", sans-serif;
     -fx-font-size: 12px;
     -fx-text-fill: black;
 }
@@ -96,7 +89,7 @@
     -fx-border-radius: 2;
     -fx-background-radius: 2;
     -fx-font-size: 11;
-    -fx-font-family: "Segoe UI";
+    -fx-font-family: "Noto Sans CJK SC Bold", "Segoe UI", sans-serif;
     -fx-font-weight: bold;
     -fx-text-fill: #e0e0e0;
 }
@@ -112,8 +105,9 @@
 }
 
 .status-bar .label {
-    -fx-font-family: "Segoe UI";
+    -fx-font-family: "Noto Sans CJK SC Bold", "Segoe UI", sans-serif;
     -fx-font-weight: bold;
     -fx-font-size: 9pt;
     -fx-text-fill: black;
 }
+

--- a/src/main/resources/view/MainWindow.fxml
+++ b/src/main/resources/view/MainWindow.fxml
@@ -19,17 +19,18 @@
         <URL value="@Extensions.css" />
       </stylesheets>
 
-      <VBox styleClass="app-root">
-        <StackPane VBox.vgrow="NEVER" fx:id="commandBoxContainer" styleClass="command-input-root" />
+      <VBox styleClass="app-root" minWidth="512" minHeight="700">
+        <StackPane fx:id="commandBoxContainer" styleClass="command-input-root" />
 
-        <StackPane VBox.vgrow="NEVER" fx:id="resultDisplayContainer" styleClass="result-display-root"
+        <StackPane fx:id="resultDisplayContainer" styleClass="result-display-root"
             minHeight="120" maxHeight="120" />
 
-        <VBox fx:id="contentRoot" styleClass="content-root" minWidth="340" prefWidth="340" VBox.vgrow="ALWAYS">
-          <StackPane fx:id="contentContainer" VBox.vgrow="ALWAYS" styleClass="content-display" />
+        <VBox fx:id="contentRoot" styleClass="content-root" VBox.vgrow="ALWAYS">
+          <StackPane fx:id="contentContainer" styleClass="content-display"
+            VBox.vgrow="ALWAYS"/>
         </VBox>
 
-        <StackPane fx:id="statusBarContainer" VBox.vgrow="NEVER" styleClass="status-bar-root" />
+        <StackPane fx:id="statusBarContainer" styleClass="status-bar-root" />
       </VBox>
     </Scene>
   </scene>


### PR DESCRIPTION
## Fix FXML and CSS that was parsed incorrectly on Ubuntu
Summary: Repairs broken app GUI on Ubuntu due to differences in OpenJFX parsing of FXML and CSS files between different OSes. Fixes #95.

### Changelog
- Update structural attributes of UI components in `MainWindow.fxml` and font choices in CSS files
   - No visual change to app GUI on Windows 10

### Screenshots

#### App GUI on Ubuntu 16.04 LTS
![splitwiser-base-ui-ubuntu](https://user-images.githubusercontent.com/44989315/67078878-c1ded100-f1c4-11e9-89f1-f5bb4e5d0a54.png)

Last updated 18 Oct 2019, 05:00PM