### PR TITLE
Add invite/disinvite method for Activity Class

### DIFF
--- a/src/main/java/seedu/address/logic/commands/ExpenseCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ExpenseCommand.java
@@ -111,7 +111,9 @@ public class ExpenseCommand extends Command {
 
             // Contextual behaviour
             if (model.getContext().getType() != Context.Type.VIEW_ACTIVITY) {
-                activity.invite(person);
+                if (!activity.hasPerson(person.getPrimaryKey())) {
+                    activity.invite(person.getPrimaryKey());
+                }
             }
         }
 

--- a/src/main/java/seedu/address/model/activity/Activity.java
+++ b/src/main/java/seedu/address/model/activity/Activity.java
@@ -5,8 +5,6 @@ import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 import java.util.ArrayList;
 import java.util.Objects;
 
-import seedu.address.model.person.Person;
-
 /**
  * Represents an Activity class containing participants ID and expenses.
  */
@@ -54,20 +52,28 @@ public class Activity {
     }
 
     /**
-     * Invite people to the activity.
-     * @param people The people that will be added into the activity.
+     * Checks whether the person with ID is present in this activity.
+     * @param personId Id of the person to check.
+     * @return True if person exists, false otherwise.
      */
-    public void invite(Person ... people) {
-        // TODO: implement check for person with same name, add only if
-        // different name
+    public boolean hasPerson(Integer personId) {
+        return participantIds.contains(personId);
+    }
+
+    /**
+     * Invite a person into the activity.
+     * @param personId ID of the person to be invited.
+     */
+    public void invite(Integer personId) {
+        participantIds.add(personId);
     }
 
     /**
      * Remove people from the activity
-     * @param people The people that will be removed from the activity.
+     * @param personId The people that will be removed from the activity.
      */
-    public void disinvite(Person ... people) {
-        // haven't implemented what if list does not contain that specific person
+    public void disinvite(Integer personId) {
+        participantIds.remove(personId);
     }
 
     /**

--- a/src/main/java/seedu/address/model/activity/Activity.java
+++ b/src/main/java/seedu/address/model/activity/Activity.java
@@ -7,7 +7,6 @@ import java.util.Objects;
 import java.util.stream.Stream;
 
 import seedu.address.model.activity.exceptions.PersonNotInActivityException;
-import seedu.address.model.person.Person;
 
 /**
  * Represents an Activity class containing participants ID and expenses.

--- a/src/test/java/seedu/address/model/activity/ActivityTest.java
+++ b/src/test/java/seedu/address/model/activity/ActivityTest.java
@@ -12,6 +12,17 @@ import seedu.address.testutil.TypicalPersons;
 public class ActivityTest {
 
     @Test
+    public void hasPerson() {
+        Activity lunch = TypicalActivities.LUNCH;
+
+        // Person exists -> Return true
+        assertTrue(lunch.hasPerson(TypicalPersons.BENSON.getPrimaryKey()));
+
+        // Person doesn't exist -> return false
+        assertFalse(lunch.hasPerson(TypicalPersons.ALICE.getPrimaryKey()));
+    }
+
+    @Test
     public void equals() {
         // same values -> returns true
         Activity lunch = TypicalActivities.LUNCH;

--- a/src/test/java/seedu/address/model/activity/ActivityTest.java
+++ b/src/test/java/seedu/address/model/activity/ActivityTest.java
@@ -1,7 +1,10 @@
 package seedu.address.model.activity;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
 
 import org.junit.jupiter.api.Test;
 
@@ -10,6 +13,16 @@ import seedu.address.testutil.TypicalActivities;
 import seedu.address.testutil.TypicalPersons;
 
 public class ActivityTest {
+
+    @Test
+    public void getParticipantIds() {
+        Activity lunch = TypicalActivities.LUNCH;
+        ArrayList<Integer> expectedIds = new ArrayList<Integer>();
+        expectedIds.add(TypicalPersons.BENSON.getPrimaryKey());
+        expectedIds.add(TypicalPersons.CARL.getPrimaryKey());
+
+        assertEquals(lunch.getParticipantIds(), expectedIds);
+    }
 
     @Test
     public void hasPerson() {


### PR DESCRIPTION
### Context
This PR updates the invite/disinvite method to be functional, so that the invite/disinvite method can be called by their respective command.

### Changes
- Updated `invite` method to take in the ID of the participants and add them to the activity.
- Updated `disinvite` method to take in the ID of the participants to be removed, and remove them from activity.
- Created an `hasPerson` method for `Activity` class, that checks if a person exists in the activity.
- Fixed a bug in `ExpenseCommand` where a same person can be added multiple times to a same activity, when used outside of view Activity context


### Considerations
- Initially thought about doing validations in the invite/disinvite method, but I realised that some of the validations (checking whether a person exists) must be already done in the command class itself. I don't think its ideal to split the validations between the two classes, so for now all validations should be done in the command class. @JohnNzj take note