### PR TITLE
Fix expense command behaviour

### DIFF
--- a/docs/UserGuide.adoc
+++ b/docs/UserGuide.adoc
@@ -59,7 +59,6 @@ SplitWiser also saves its application state with your data - meaning you can re-
 * Words in `UPPER_CASE` are the parameters to be supplied by the user e.g. in `contact n/CONTACT_NAME`, `CONTACT_NAME` is a parameter which can be used as `add n/John Doe`.
 * Parameters in square brackets are optional e.g `n/ACTIVITY_NAME [p/PERSON_1]` can be used as `n/Drinks p/John Doe` or as `n/Drinks`.
 * Parameters with `…`​ may be supplied multiple times, including 0 times for optional parameters, e.g. `[t/TAG]...` can be used as `{nbsp}` (i.e. 0 times), `t/friend`, `t/friend t/family` etc.
-* Parameters in brackets must be supplied together - e.g. addition of expenses to an activity requires contact-expense pairs `(n/CONTACT_NAME && e/EXPENSE_AMT)`, which may be used as `p/John Doe e/50.25`
 * Parameters may be supplied in any order e.g. if the command specifies `n/NAME hp/PHONE_NUMBER`, `hp/PHONE_NUMBER n/NAME` is also acceptable.
 ====
 
@@ -163,7 +162,7 @@ If only one contact is specified in the list, then SplitWiser will assume that a
 
 If no activity is being viewed, the description is compulsory - a new activity will instead be created with the same title as the description (as if `activity t/ACTIVITY_NAME` was called). The expense and contact(s) will then be added to the activity. +
 
-Format: `expense (p/PERSON e/AMOUNT_PAID) [p/PERSON ...] [d/DESCRIPTION]`
+Format: `expense p/PERSON e/AMOUNT_PAID [p/PERSON ...] [d/DESCRIPTION]`
 
 ****
 * Exactly one expense amount must be provided.

--- a/src/main/java/seedu/address/logic/commands/ExpenseCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ExpenseCommand.java
@@ -141,7 +141,7 @@ public class ExpenseCommand extends Command {
         }
 
         return new CommandResult(String.format(MESSAGE_SUCCESS,
-                payingPerson.getName(), amount, description, successMessage.toString()));
+                amount, payingPerson.getName(), description, successMessage.toString()));
     }
 
     /**

--- a/src/main/java/seedu/address/logic/commands/ExpenseCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ExpenseCommand.java
@@ -42,7 +42,7 @@ public class ExpenseCommand extends Command {
             + PREFIX_DESCRIPTION + "Bubble tea";
 
     public static final String MESSAGE_SUCCESS =
-            "Expense of %s by %s successfully created.\n  Description: %s\n  People involved: %s";
+            "Expense of %s by %s successfully created.\n\tDescription: %s\n\tPeople involved:\n\t\t%s";
     public static final String MESSAGE_NON_UNIQUE_SEARCH_RESULT =
             "Participant search term \"%s\" has no unique search result in the current context!";
     public static final String MESSAGE_MISSING_DESCRIPTION =

--- a/src/main/java/seedu/address/logic/commands/ExpenseCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ExpenseCommand.java
@@ -123,7 +123,10 @@ public class ExpenseCommand extends Command {
                     }
                 }
             }
-            involvedArr = personList.stream().mapToInt(x -> x.getPrimaryKey()).toArray();
+            involvedArr = personList.stream()
+                    .filter(x -> x.getPrimaryKey() != payingId)
+                    .mapToInt(x -> x.getPrimaryKey())
+                    .toArray();
         } else {
             // Contextual behaviour
             if (model.getContext().getType() == ContextType.VIEW_ACTIVITY) {

--- a/src/main/java/seedu/address/storage/JsonAdaptedExpense.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedExpense.java
@@ -51,6 +51,10 @@ class JsonAdaptedExpense {
         }
         final Amount amount = new Amount(this.amount);
 
-        return new Expense(personId, amount, description, involvedIds);
+        if (involvedIds.length > 0) {
+            return new Expense(personId, amount, description, involvedIds);
+        } else {
+            return new Expense(personId, amount, description);
+        }
     }
 }

--- a/src/main/java/seedu/address/storage/JsonAdaptedExpense.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedExpense.java
@@ -13,6 +13,7 @@ import seedu.address.model.activity.Expense;
 class JsonAdaptedExpense {
 
     private final int personId;
+    private final int[] involvedIds;
     private final double amount;
     private final String description;
 
@@ -21,10 +22,12 @@ class JsonAdaptedExpense {
      */
     @JsonCreator
     public JsonAdaptedExpense(@JsonProperty("personId") int personId, @JsonProperty("amount") double amount,
-                              @JsonProperty("description") String description) {
+                              @JsonProperty("description") String description,
+                              @JsonProperty("involvedIds") int ... involvedIds) {
         this.personId = personId;
         this.amount = amount;
         this.description = description;
+        this.involvedIds = involvedIds;
     }
 
     /**
@@ -34,6 +37,7 @@ class JsonAdaptedExpense {
         personId = source.getPersonId();
         amount = source.getAmount().value;
         description = source.getDescription();
+        involvedIds = source.getInvolved();
     }
 
     /**
@@ -47,6 +51,6 @@ class JsonAdaptedExpense {
         }
         final Amount amount = new Amount(this.amount);
 
-        return new Expense(personId, amount, description);
+        return new Expense(personId, amount, description, involvedIds);
     }
 }

--- a/src/main/java/seedu/address/storage/JsonAdaptedExpense.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedExpense.java
@@ -51,10 +51,10 @@ class JsonAdaptedExpense {
         }
         final Amount amount = new Amount(this.amount);
 
-        if (involvedIds.length > 0) {
-            return new Expense(personId, amount, description, involvedIds);
-        } else {
+        if (involvedIds == null) {
             return new Expense(personId, amount, description);
+        } else {
+            return new Expense(personId, amount, description, involvedIds);
         }
     }
 }

--- a/src/test/java/seedu/address/logic/commands/ExpenseCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ExpenseCommandTest.java
@@ -62,7 +62,8 @@ public class ExpenseCommandTest {
         CommandResult commandResult = commandOneName.execute(model);
 
         assertEquals(String.format(ExpenseCommand.MESSAGE_SUCCESS,
-                amount, TypicalPersons.ALICE.getName(), emptyString, TypicalPersons.BENSON.getName() + "\n"),
+                amount, TypicalPersons.ALICE.getName(), emptyString,
+                "\t\t" + TypicalPersons.BENSON.getName() + "\n"),
                 commandResult.getFeedbackToUser());
 
         expenses.clear(); // for some odd reason @BeforeAll doesn't do this properly?
@@ -71,6 +72,38 @@ public class ExpenseCommandTest {
                 amount,
                 emptyString,
                 TypicalPersons.BENSON.getPrimaryKey()));
+        assertEquals(expenses, model.getActivityBook().getActivityList().get(0).getExpenses());
+    }
+
+    @Test
+    public void execute_activityViewContextNameSubstring_addSuccessful() throws Exception {
+        Activity validActivity = new ActivityBuilder()
+                .addPerson(TypicalPersons.GEORGE)
+                .addPerson(TypicalPersons.GEORGE_FIRSTNAME)
+                .build();
+        Model model = new ModelManager();
+        model.addPerson(TypicalPersons.GEORGE);
+        model.addPerson(TypicalPersons.GEORGE_FIRSTNAME);
+        model.addActivity(validActivity);
+        model.setContext(new Context(validActivity));
+
+        ArrayList<String> search = new ArrayList<>();
+        search.add("George");
+        ExpenseCommand cmd = new ExpenseCommand(search, amount, emptyString);
+
+        CommandResult commandResult = cmd.execute(model);
+
+        assertEquals(String.format(ExpenseCommand.MESSAGE_SUCCESS,
+                amount, TypicalPersons.GEORGE_FIRSTNAME.getName(),
+                emptyString, "\t\t" + TypicalPersons.GEORGE.getName() + "\n"),
+                commandResult.getFeedbackToUser());
+
+        expenses.clear();
+        expenses.add(new Expense(
+                TypicalPersons.GEORGE_FIRSTNAME.getPrimaryKey(),
+                amount,
+                emptyString,
+                TypicalPersons.GEORGE.getPrimaryKey()));
         assertEquals(expenses, model.getActivityBook().getActivityList().get(0).getExpenses());
     }
 
@@ -95,7 +128,8 @@ public class ExpenseCommandTest {
         CommandResult commandResult = commandMultipleNames.execute(model);
 
         assertEquals(String.format(ExpenseCommand.MESSAGE_SUCCESS,
-                amount, TypicalPersons.ALICE.getName(), emptyString, TypicalPersons.BENSON.getName() + "\n"),
+                amount, TypicalPersons.ALICE.getName(), emptyString,
+                "\t\t" + TypicalPersons.BENSON.getName() + "\n"),
                 commandResult.getFeedbackToUser());
 
         expenses.clear();
@@ -126,7 +160,8 @@ public class ExpenseCommandTest {
         CommandResult commandResult = command.execute(model);
 
         assertEquals(String.format(ExpenseCommand.MESSAGE_SUCCESS,
-                amount, TypicalPersons.ALICE.getName(), notEmptyString, TypicalPersons.BENSON.getName() + "\n"),
+                amount, TypicalPersons.ALICE.getName(), notEmptyString,
+                "\t\t" + TypicalPersons.BENSON.getName() + "\n"),
                 commandResult.getFeedbackToUser());
 
         // It should add a whole activity wrapping all the contacts, and then

--- a/src/test/java/seedu/address/logic/commands/ExpenseCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ExpenseCommandTest.java
@@ -178,4 +178,33 @@ public class ExpenseCommandTest {
                         .build(),
                 model.getActivityBook().getActivityList().get(0));
     }
+
+    @Test
+    public void execute_duplicateNamesAdded_addSuccessfulWithWarning() throws Exception {
+        Model model = new ModelManager();
+        model.addPerson(TypicalPersons.ALICE);
+        model.addPerson(TypicalPersons.BENSON);
+
+        ArrayList<String> personsDuplicate = new ArrayList<>(persons);
+        personsDuplicate.addAll(persons);
+        ExpenseCommand command = new ExpenseCommand(personsDuplicate, amount, notEmptyString);
+        CommandResult commandResult = command.execute(model);
+
+        assertEquals(String.format(ExpenseCommand.MESSAGE_SUCCESS,
+                amount, TypicalPersons.ALICE.getName(), notEmptyString,
+                "\t\t" + TypicalPersons.BENSON.getName() + "\n")
+                + String.format(ExpenseCommand.WARNING_DUPLICATE_PERSON, TypicalPersons.ALICE.getName())
+                + String.format(ExpenseCommand.WARNING_DUPLICATE_PERSON, TypicalPersons.BENSON.getName()),
+                commandResult.getFeedbackToUser());
+
+        Expense expense = new Expense(TypicalPersons.ALICE.getPrimaryKey(), amount,
+                notEmptyString, TypicalPersons.BENSON.getPrimaryKey());
+
+        assertEquals(new ActivityBuilder()
+                        .withTitle(notEmptyString)
+                        .addPerson(TypicalPersons.ALICE).addPerson(TypicalPersons.BENSON)
+                        .addExpense(expense)
+                        .build(),
+                model.getActivityBook().getActivityList().get(0));
+    }
 }

--- a/src/test/java/seedu/address/logic/commands/ExpenseCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ExpenseCommandTest.java
@@ -62,7 +62,7 @@ public class ExpenseCommandTest {
         CommandResult commandResult = commandOneName.execute(model);
 
         assertEquals(String.format(ExpenseCommand.MESSAGE_SUCCESS,
-                TypicalPersons.ALICE.getName(), amount, emptyString, TypicalPersons.BENSON.getName() + "\n"),
+                amount, TypicalPersons.ALICE.getName(), emptyString, TypicalPersons.BENSON.getName() + "\n"),
                 commandResult.getFeedbackToUser());
 
         expenses.clear(); // for some odd reason @BeforeAll doesn't do this properly?
@@ -95,7 +95,7 @@ public class ExpenseCommandTest {
         CommandResult commandResult = commandMultipleNames.execute(model);
 
         assertEquals(String.format(ExpenseCommand.MESSAGE_SUCCESS,
-                TypicalPersons.ALICE.getName(), amount, emptyString, TypicalPersons.BENSON.getName() + "\n"),
+                amount, TypicalPersons.ALICE.getName(), emptyString, TypicalPersons.BENSON.getName() + "\n"),
                 commandResult.getFeedbackToUser());
 
         expenses.clear();
@@ -126,7 +126,7 @@ public class ExpenseCommandTest {
         CommandResult commandResult = command.execute(model);
 
         assertEquals(String.format(ExpenseCommand.MESSAGE_SUCCESS,
-                TypicalPersons.ALICE.getName(), amount, notEmptyString, TypicalPersons.BENSON.getName() + "\n"),
+                amount, TypicalPersons.ALICE.getName(), notEmptyString, TypicalPersons.BENSON.getName() + "\n"),
                 commandResult.getFeedbackToUser());
 
         // It should add a whole activity wrapping all the contacts, and then

--- a/src/test/java/seedu/address/storage/JsonAdaptedExpenseTest.java
+++ b/src/test/java/seedu/address/storage/JsonAdaptedExpenseTest.java
@@ -2,6 +2,7 @@ package seedu.address.storage;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static seedu.address.testutil.Assert.assertThrows;
+import static seedu.address.testutil.TypicalPersons.ALICE;
 import static seedu.address.testutil.TypicalPersons.BENSON;
 
 import org.junit.jupiter.api.Test;
@@ -12,11 +13,16 @@ import seedu.address.model.activity.Expense;
 
 public class JsonAdaptedExpenseTest {
     private static Expense expense = new Expense(BENSON.getPrimaryKey(), new Amount(1.5), "Fish fillet");
+    private static Expense expense2 =
+            new Expense(BENSON.getPrimaryKey(), new Amount(1.5), "Fish fillet", ALICE.getPrimaryKey());
 
     @Test
     public void toModelType_validExpenseDetails_returnsExpense() throws Exception {
         JsonAdaptedExpense jsonAdaptedExpense = new JsonAdaptedExpense(expense);
         assertEquals(expense, jsonAdaptedExpense.toModelType());
+
+        jsonAdaptedExpense = new JsonAdaptedExpense(expense2);
+        assertEquals(expense2, jsonAdaptedExpense.toModelType());
     }
 
     @Test


### PR DESCRIPTION
*Changelog:*
- Change expense command to not use updateFilteredPersonList to avoid affecting GUI
- Update command result output
- Update tests
- Update JsonAdaptedExpense to properly store the involved participants
- Updated expense command behaviour:
1. If only payer is specified and it is currently in an activity view context, everyone in the current activity is taken to be involved.
2. On the contrary, if expense is created outside activity view context and only payer is specified, then only one person (the payer) is actually added into the activity and the expense is taken to not involve anyone else besides the payer.
3. If duplicate names are specified, they will only be added into the expense once and warnings will be shown accordingly.