### PR TITLE
ActivityCommand substring bugfix and contact command prevent duplicate name

### DIFF
--- a/docs/DeveloperGuide.adoc
+++ b/docs/DeveloperGuide.adoc
@@ -218,7 +218,7 @@ All `Activity` models are stored inside `ActivityBook`.
 
 When creating an activity, the title must be specified. It is optional to include participants, as they can be invited separately.
 
-Adding of participant relies on keyword-based search. A set of keyword is passed in for each participant to be invited in. The keywords are used to search the AddressBook for a matching person. The person is added in as a participant only if there is one exact match. Otherwise, a warning message will be displayed and no participant will be added for this set of keywords.
+Adding of participant uses both exact-match and keyword-based search. First, the search term passed in is used to find an contact with an exact matching name. If no exact match is found, the search term is split into keywords via whitespace. Obtained keywords are then used to search the AddressBook for a matching person. The person is added in as a participant only if there is one exact match. Otherwise, a warning message will be displayed and no participant will be added for this set of keywords.
 
 Given below is an example usage scenario and how the create activity mechanism behaves at each step.
 

--- a/docs/UserGuide.adoc
+++ b/docs/UserGuide.adoc
@@ -117,7 +117,8 @@ Creates a new activity with a title, contacts (optional) and no expenses.
 ****
 * The user creating the activity will be included automatically.
 * Additional contacts to add to the activity can be specified by using `p/` prefix.
-** Keyword matching is used to find contacts to add to the activity. Refer to <<Finding contacts or activities: `find`>> for more details.
+** Initially, the application will search for contact with exact matching name.
+** If no exact match is found, keyword matching is used instead. Refer to <<Finding contacts or activities: `find`>> for more details.
 ** For a contact to be successfully added, given keywords must have exact 1 matching contact. Otherwise, the activity will be created without adding the contact suggested by the keywords, and warning message will be shown.
 * Changes the current view to this activity (as if `view a/ACTIVITY_ID` was called).
 * Each activity will be assigned an activity ID automatically. +

--- a/src/main/java/seedu/address/logic/commands/ActivityCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ActivityCommand.java
@@ -10,6 +10,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Context;
@@ -71,17 +72,24 @@ public class ActivityCommand extends Command {
         // Participant will only be added if the keyword has a unique match.
         for (String searchTerm : participants) {
 
-            keywords = Arrays.asList(searchTerm.split(" "));
-            NameContainsAllKeywordsPredicate predicate = new NameContainsAllKeywordsPredicate(keywords);
-            findResult = model.findPersonAll(predicate);
+            //Check for exact match case
+            Optional<Person> exactMatch = model.findPersonByName(searchTerm);
+            if (exactMatch.isPresent()) {
+                toAddPerson = exactMatch.get();
+            } else {
 
-            // Non-unique match (0 or more than 1) - this argument is skipped
-            if (findResult.size() != 1) {
-                updateWarningNotSingleMatch(warningMessage, searchTerm, findResult.size());
-                continue;
+                keywords = Arrays.asList(searchTerm.split(" "));
+                NameContainsAllKeywordsPredicate predicate = new NameContainsAllKeywordsPredicate(keywords);
+                findResult = model.findPersonAll(predicate);
+
+                // Non-unique match (0 or more than 1) - this argument is skipped
+                if (findResult.size() != 1) {
+                    updateWarningNotSingleMatch(warningMessage, searchTerm, findResult.size());
+                    continue;
+                }
+                toAddPerson = findResult.get(0);
             }
 
-            toAddPerson = findResult.get(0);
             id = toAddPerson.getPrimaryKey();
 
             // Person already in this activity - this person is not added

--- a/src/main/java/seedu/address/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCommand.java
@@ -33,6 +33,7 @@ public class AddCommand extends Command {
 
     public static final String MESSAGE_SUCCESS = "New contact added: %1$s";
     public static final String MESSAGE_DUPLICATE_PERSON = "This contact already exists in the address book";
+    public static final String MESSAGE_DUPLICATE_NAME = "There already exists a name with the exact same name";
 
     private final Person toAdd;
 
@@ -50,6 +51,9 @@ public class AddCommand extends Command {
 
         if (model.hasPerson(toAdd)) {
             throw new CommandException(MESSAGE_DUPLICATE_PERSON);
+        }
+        if (model.findPersonByName(toAdd.getName().fullName).isPresent()) {
+            throw new CommandException(MESSAGE_DUPLICATE_NAME);
         }
 
         model.addPerson(toAdd);

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -4,6 +4,7 @@ import static java.util.Objects.requireNonNull;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 import javafx.collections.ObservableList;
 import seedu.address.model.person.NameContainsAllKeywordsPredicate;
@@ -95,6 +96,18 @@ public class AddressBook implements ReadOnlyAddressBook {
         }
 
         return matches;
+    }
+
+    /**
+     * Finds Person object by name, using exact match.
+     */
+    public Optional<Person> findPersonByName(String searchTerm) {
+        for (Person person: persons.asUnmodifiableObservableList()) {
+            if (person.getName().fullName.toLowerCase().equals(searchTerm.toLowerCase())) {
+                return Optional.of(person);
+            }
+        }
+        return Optional.empty();
     }
 
     /**

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -2,6 +2,7 @@ package seedu.address.model;
 
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.Optional;
 import java.util.function.Predicate;
 
 import javafx.collections.ObservableList;
@@ -87,14 +88,19 @@ public interface Model {
     boolean hasPerson(Person person);
 
     /**
-       Finds Person objects with matching keywords, returning matches in ArrayList.
+     * Finds Person objects with matching keywords, returning matches in ArrayList.
      */
     ArrayList<Person> findPersonAny(NameContainsKeywordsPredicate predicate);
 
     /**
-     Finds Person objects with names matching all keywords, returning matches in ArrayList.
+     * Finds Person objects with names matching all keywords, returning matches in ArrayList.
      */
     ArrayList<Person> findPersonAll(NameContainsAllKeywordsPredicate predicate);
+
+    /**
+     * Finds Person object that has exact matching name as the search term provided, returning an Optional of Person.
+     */
+    Optional<Person> findPersonByName(String searchTerm);
 
     /**
      * Deletes the given person.

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -5,6 +5,7 @@ import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.Optional;
 import java.util.function.Predicate;
 import java.util.logging.Logger;
 
@@ -158,6 +159,12 @@ public class ModelManager implements Model {
     public ArrayList<Person> findPersonAll(NameContainsAllKeywordsPredicate predicate) {
         requireNonNull(predicate);
         return addressBook.findPerson(predicate);
+    }
+
+    @Override
+    public Optional<Person> findPersonByName(String searchTerm) {
+        requireNonNull(searchTerm);
+        return addressBook.findPersonByName(searchTerm);
     }
 
     @Override

--- a/src/test/java/seedu/address/logic/commands/ActivityCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ActivityCommandTest.java
@@ -9,10 +9,13 @@ import static seedu.address.testutil.Assert.assertThrows;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
+import java.util.function.Predicate;
 
 import org.junit.jupiter.api.Test;
 
 import seedu.address.model.ActivityBook;
+import seedu.address.model.Context;
 import seedu.address.model.activity.Activity;
 import seedu.address.model.activity.Title;
 import seedu.address.model.person.NameContainsAllKeywordsPredicate;
@@ -30,9 +33,7 @@ public class ActivityCommandTest {
         assertThrows(NullPointerException.class, () -> new ActivityCommand(null, null));
     }
 
-    /**
-     * TODO: put this back after abstracting out view change @Test
-     */
+    @Test
     public void execute_validActivityWithoutParticipants_addSuccessful() throws Exception {
         ModelStubAcceptingActivityAdded modelStub = new ModelStubAcceptingActivityAdded();
         Activity validActivity = new ActivityBuilder().build();
@@ -46,9 +47,7 @@ public class ActivityCommandTest {
         assertEquals(Arrays.asList(validActivity), modelStub.activityList);
     }
 
-    /**
-     * TODO: put this back after abstracting out view change @Test
-     */
+    @Test
     public void execute_validActivityWithParticipant_addSuccessful() throws Exception {
         ModelStubAcceptingActivityAdded modelStub = new ModelStubAcceptingActivityAdded();
         Activity validActivity = new ActivityBuilder().addPerson(TypicalPersons.ALICE).build();
@@ -64,9 +63,26 @@ public class ActivityCommandTest {
         assertEquals(Arrays.asList(validActivity), modelStub.activityList);
     }
 
-    /**
-     * TODO: put this back after abstracting out view change @Test
-     */
+    @Test
+    public void execute_validActivityWithExactMatchParticipant_addSuccessful() throws Exception {
+        ModelStubAcceptingActivityAdded modelStub = new ModelStubAcceptingActivityAdded();
+        modelStub.addPerson(TypicalPersons.GEORGE_FIRSTNAME);
+        Activity validActivity = new ActivityBuilder()
+                .addPerson(TypicalPersons.GEORGE_FIRSTNAME).build();
+
+        ArrayList<String> searchTerms = new ArrayList<String>();
+        searchTerms.add("George");
+
+        CommandResult commandResult =
+                new ActivityCommand(new Title(ActivityBuilder.DEFAULT_TITLE), searchTerms)
+                .execute(modelStub);
+
+        assertEquals(String.format(ActivityCommand.MESSAGE_SUCCESS, validActivity, "George", ""),
+                commandResult.getFeedbackToUser());
+        assertEquals(Arrays.asList(validActivity), modelStub.activityList);
+    }
+
+    @Test
     public void execute_validActivityWithInvalidParticipant_multipleMatches() throws Exception {
         ModelStubAcceptingActivityAdded modelStub = new ModelStubAcceptingActivityAdded();
         modelStub.addPerson(TypicalPersons.ANDY);
@@ -144,6 +160,17 @@ public class ActivityCommandTest {
         }
 
         @Override
+        public Optional<Person> findPersonByName(String searchTerm) {
+            requireNonNull(searchTerm);
+            for (Person person : personList) {
+                if (person.getName().fullName.toLowerCase().equals(searchTerm.toLowerCase())) {
+                    return Optional.of(person);
+                }
+            }
+            return Optional.empty();
+        }
+
+        @Override
         public void addActivity(Activity activity) {
             requireNonNull(activity);
             activityList.add(activity);
@@ -154,6 +181,16 @@ public class ActivityCommandTest {
             ActivityBook activityBook = new ActivityBook();
             activityBook.setActivities(activityList);
             return activityBook;
+        }
+
+        @Override
+        public void setContext(Context context) {
+            return;
+        }
+
+        @Override
+        public void updateFilteredPersonList(Predicate<? super Person> predicate) {
+            return;
         }
     }
 

--- a/src/test/java/seedu/address/logic/commands/AddCommandIntegrationTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandIntegrationTest.java
@@ -30,7 +30,7 @@ public class AddCommandIntegrationTest {
 
     @Test
     public void execute_newPerson_success() {
-        Person validPerson = new PersonBuilder().build();
+        Person validPerson = new PersonBuilder().withName("Alice Bob").build();
 
         Model expectedModel = new ModelManager(
                 model.getAddressBook(), new UserPrefs(), new InternalState(), new ActivityBook());
@@ -44,6 +44,13 @@ public class AddCommandIntegrationTest {
     public void execute_duplicatePerson_throwsCommandException() {
         Person personInList = model.getAddressBook().getPersonList().get(0);
         assertCommandFailure(new AddCommand(personInList), model, AddCommand.MESSAGE_DUPLICATE_PERSON);
+    }
+
+    @Test
+    public void execute_duplicateName_throwsCommandException() {
+        Person personInList = model.getAddressBook().getPersonList().get(0);
+        Person duplicateNamePerson = new PersonBuilder().withName(personInList.getName().fullName).build();
+        assertCommandFailure(new AddCommand(duplicateNamePerson), model, AddCommand.MESSAGE_DUPLICATE_NAME);
     }
 
 }

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -8,6 +8,7 @@ import static seedu.address.testutil.Assert.assertThrows;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Optional;
 
 import org.junit.jupiter.api.Test;
 
@@ -17,6 +18,7 @@ import seedu.address.model.ReadOnlyAddressBook;
 import seedu.address.model.person.Person;
 import seedu.address.stub.ModelStub;
 import seedu.address.testutil.PersonBuilder;
+import seedu.address.testutil.TypicalPersons;
 
 public class AddCommandTest {
 
@@ -40,9 +42,20 @@ public class AddCommandTest {
     public void execute_duplicatePerson_throwsCommandException() {
         Person validPerson = new PersonBuilder().build();
         AddCommand addCommand = new AddCommand(validPerson);
-        ModelStub modelStub = new ModelStubWithPerson(validPerson);
+        ModelStub modelStub = new ModelStubAcceptingPersonAdded();
+        modelStub.addPerson(validPerson);
 
         assertThrows(CommandException.class, AddCommand.MESSAGE_DUPLICATE_PERSON, () -> addCommand.execute(modelStub));
+    }
+
+    @Test
+    public void execute_duplicateName_throwsCommandException() {
+        Person invalidPerson = new PersonBuilder().withName("George Best").build();
+        AddCommand addCommand = new AddCommand(invalidPerson);
+        ModelStub modelStub = new ModelStubAcceptingPersonAdded();
+        modelStub.addPerson(TypicalPersons.GEORGE);
+
+        assertThrows(CommandException.class, AddCommand.MESSAGE_DUPLICATE_NAME, () -> addCommand.execute(modelStub));
     }
 
     @Test
@@ -70,24 +83,6 @@ public class AddCommandTest {
     }
 
     /**
-     * A Model stub that contains a single person.
-     */
-    private class ModelStubWithPerson extends ModelStub {
-        private final Person person;
-
-        ModelStubWithPerson(Person person) {
-            requireNonNull(person);
-            this.person = person;
-        }
-
-        @Override
-        public boolean hasPerson(Person person) {
-            requireNonNull(person);
-            return this.person.isSamePerson(person);
-        }
-    }
-
-    /**
      * A Model stub that always accept the person being added.
      */
     private class ModelStubAcceptingPersonAdded extends ModelStub {
@@ -108,6 +103,17 @@ public class AddCommandTest {
         @Override
         public ReadOnlyAddressBook getAddressBook() {
             return new AddressBook();
+        }
+
+        @Override
+        public Optional<Person> findPersonByName(String searchTerm) {
+            requireNonNull(searchTerm);
+            for (Person person : personsAdded) {
+                if (person.getName().fullName.toLowerCase().equals(searchTerm.toLowerCase())) {
+                    return Optional.of(person);
+                }
+            }
+            return Optional.empty();
         }
     }
 

--- a/src/test/java/seedu/address/model/AddressBookTest.java
+++ b/src/test/java/seedu/address/model/AddressBookTest.java
@@ -7,6 +7,7 @@ import static seedu.address.logic.commands.CommandTestUtil.VALID_ADDRESS_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalPersons.ALICE;
+import static seedu.address.testutil.TypicalPersons.GEORGE_FIRSTNAME;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 
 import java.util.ArrayList;
@@ -14,6 +15,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 
 import org.junit.jupiter.api.Test;
 
@@ -89,6 +91,35 @@ public class AddressBookTest {
         ArrayList<Person> expectedSearchResult = new ArrayList<Person>(Arrays.asList(ALICE));
         assertEquals(expectedSearchResult, searchResult);
     }
+
+    @Test
+    public void findPersonByName_personInAddressBook_returnsCorrect() {
+        AddressBook addressBook = getTypicalAddressBook();
+        String searchTerm = "alice pauline";
+        Optional<Person> searchResult = addressBook.findPersonByName(searchTerm);
+        Optional<Person> expectedSearchResult = Optional.of(ALICE);
+        assertEquals(expectedSearchResult, searchResult);
+    }
+
+    @Test
+    public void findPersonByName_subStringEdgeCase_returnsCorrect() {
+        AddressBook addressBook = getTypicalAddressBook();
+        addressBook.addPerson(GEORGE_FIRSTNAME);
+        String searchTerm = "George";
+        Optional<Person> searchResult = addressBook.findPersonByName(searchTerm);
+        Optional<Person> expectedSearchResult = Optional.of(GEORGE_FIRSTNAME);
+        assertEquals(expectedSearchResult, searchResult);
+    }
+
+    @Test
+    public void findPersonByName_personNotInAddressBook_returnsEmpty() {
+        AddressBook addressBook = getTypicalAddressBook();
+        String searchTerm = "Nonexistent person";
+        Optional<Person> searchResult = addressBook.findPersonByName(searchTerm);
+        Optional<Person> expectedSearchResult = Optional.empty();
+        assertEquals(expectedSearchResult, searchResult);
+    }
+
 
     @Test
     public void getPersonList_modifyList_throwsUnsupportedOperationException() {

--- a/src/test/java/seedu/address/model/ModelManagerTest.java
+++ b/src/test/java/seedu/address/model/ModelManagerTest.java
@@ -8,12 +8,15 @@ import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalActivities.BREAKFAST;
 import static seedu.address.testutil.TypicalPersons.ALICE;
 import static seedu.address.testutil.TypicalPersons.BENSON;
+import static seedu.address.testutil.TypicalPersons.GEORGE;
+import static seedu.address.testutil.TypicalPersons.GEORGE_FIRSTNAME;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 
 import org.junit.jupiter.api.Test;
 
@@ -169,6 +172,25 @@ public class ModelManagerTest {
         NameContainsAllKeywordsPredicate predicate = new NameContainsAllKeywordsPredicate(keywords);
         ArrayList<Person> searchResult = modelManager.findPersonAll(predicate);
         ArrayList<Person> expectedSearchResult = new ArrayList<>(Arrays.asList(aliceFamilyMember, aliceFamilyMember2));
+        assertEquals(searchResult, expectedSearchResult);
+    }
+
+    @Test
+    public void findPersonByName_exactNameMatch_returnsSingle() {
+        modelManager.addPerson(ALICE);
+        String searchTerm = "Alice Pauline";
+        Optional<Person> searchResult = modelManager.findPersonByName(searchTerm);
+        Optional<Person> expectedSearchResult = Optional.of(ALICE);
+        assertEquals(searchResult, expectedSearchResult);
+    }
+
+    @Test
+    public void findPersonByName_subStringEdgeCase_returnsCorrect() {
+        modelManager.addPerson(GEORGE);
+        modelManager.addPerson(GEORGE_FIRSTNAME);
+        String searchTerm = "george";
+        Optional<Person> searchResult = modelManager.findPersonByName(searchTerm);
+        Optional<Person> expectedSearchResult = Optional.of(GEORGE_FIRSTNAME);
         assertEquals(searchResult, expectedSearchResult);
     }
 

--- a/src/test/java/seedu/address/stub/ModelStub.java
+++ b/src/test/java/seedu/address/stub/ModelStub.java
@@ -2,6 +2,7 @@ package seedu.address.stub;
 
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.Optional;
 import java.util.function.Predicate;
 
 import javafx.collections.ObservableList;
@@ -23,145 +24,150 @@ import seedu.address.model.person.Person;
 public class ModelStub implements Model {
     @Override
     public void setInternalState(InternalState internalState) {
-        throw new AssertionError("This method should not be called.");
+        throw new AssertionError("This method (setInternalState) should not be called.");
     }
 
     @Override
     public InternalState getInternalState() {
-        throw new AssertionError("This method should not be called.");
+        throw new AssertionError("This method (getInternalState) should not be called.");
     }
 
     @Override
     public void setContext(Context context) {
-        throw new AssertionError("This method should not be called.");
+        throw new AssertionError("This method (setContext) should not be called.");
     }
 
     @Override
     public Context getContext() {
-        throw new AssertionError("This method should not be called.");
+        throw new AssertionError("This method (getContext) should not be called.");
     }
 
     @Override
     public void setUserPrefs(ReadOnlyUserPrefs userPrefs) {
-        throw new AssertionError("This method should not be called.");
+        throw new AssertionError("This method (setUserPrefs) should not be called.");
     }
 
     @Override
     public ReadOnlyUserPrefs getUserPrefs() {
-        throw new AssertionError("This method should not be called.");
+        throw new AssertionError("This method (getUserPrefs) should not be called.");
     }
 
     @Override
     public GuiSettings getGuiSettings() {
-        throw new AssertionError("This method should not be called.");
+        throw new AssertionError("This method (getGuiSettings) should not be called.");
     }
 
     @Override
     public void setGuiSettings(GuiSettings guiSettings) {
-        throw new AssertionError("This method should not be called.");
+        throw new AssertionError("This method (setGuiSettings) should not be called.");
     }
 
     @Override
     public Path getAddressBookFilePath() {
-        throw new AssertionError("This method should not be called.");
+        throw new AssertionError("This method (getAddressBookFilePath) should not be called.");
     }
 
     @Override
     public void setAddressBookFilePath(Path addressBookFilePath) {
-        throw new AssertionError("This method should not be called.");
+        throw new AssertionError("This method (setAddressBookFilePath) should not be called.");
     }
 
     @Override
     public void addPerson(Person person) {
-        throw new AssertionError("This method should not be called.");
+        throw new AssertionError("This method (addPerson) should not be called.");
     }
 
     @Override
     public void setAddressBook(ReadOnlyAddressBook newData) {
-        throw new AssertionError("This method should not be called.");
+        throw new AssertionError("This method (setAddressBook) should not be called.");
     }
 
     @Override
     public ReadOnlyAddressBook getAddressBook() {
-        throw new AssertionError("This method should not be called.");
+        throw new AssertionError("This method (ReadOnlyAddressBook) should not be called.");
     }
 
     @Override
     public boolean hasPerson(Person person) {
-        throw new AssertionError("This method should not be called.");
+        throw new AssertionError("This method (hasPerson) should not be called.");
     }
 
     @Override
     public ArrayList<Person> findPersonAny(NameContainsKeywordsPredicate predicate) {
-        throw new AssertionError("This method should not be called.");
+        throw new AssertionError("This method (findPersonAny) should not be called.");
     }
 
     @Override
     public ArrayList<Person> findPersonAll(NameContainsAllKeywordsPredicate predicate) {
-        throw new AssertionError("This method should not be called.");
+        throw new AssertionError("This method (findPersonAll) should not be called.");
+    }
+
+    @Override
+    public Optional<Person> findPersonByName(String searchTerm) {
+        throw new AssertionError("This method (findPersonByName) should not be called.");
     }
 
     @Override
     public void deletePerson(Person target) {
-        throw new AssertionError("This method should not be called.");
+        throw new AssertionError("This method (deletePerson) should not be called.");
     }
 
     @Override
     public void setPerson(Person target, Person editedPerson) {
-        throw new AssertionError("This method should not be called.");
+        throw new AssertionError("This method (setPerson) should not be called.");
     }
 
     @Override
     public Path getActivityBookFilePath() {
-        throw new AssertionError("This method should not be called.");
+        throw new AssertionError("This method (getActivityBookFilePath) should not be called.");
     }
 
     @Override
     public ActivityBook getActivityBook() {
-        throw new AssertionError("This method should not be called.");
+        throw new AssertionError("This method (getActivityBook) should not be called.");
     }
 
     public void setActivityBook(ActivityBook activityBook) {
-        throw new AssertionError("This method should not be called.");
+        throw new AssertionError("This method (setActivityBook) should not be called.");
     }
 
     @Override
     public void setActivityBookFilePath(Path activityBookFilePath) {
-        throw new AssertionError("This method should not be called.");
+        throw new AssertionError("This method (setActivityBookFilePath) should not be called.");
     }
 
     @Override
     public void setActivity(Activity target, Activity editedActivity) {
-        throw new AssertionError("This method should not be called.");
+        throw new AssertionError("This method (setActivity) should not be called.");
     }
 
     @Override
     public void addActivity(Activity activity) {
-        throw new AssertionError("This method should not be called.");
+        throw new AssertionError("This method (addActivity) should not be called.");
     }
 
     @Override
     public void deleteActivity(Activity target) {
-        throw new AssertionError("This method should not be called.");
+        throw new AssertionError("This method (deleteActivity) should not be called.");
     }
 
     @Override
     public ObservableList<Person> getFilteredPersonList() {
-        throw new AssertionError("This method should not be called.");
+        throw new AssertionError("This method (getFilteredPersonList) should not be called.");
     }
 
     @Override
     public void updateFilteredPersonList(Predicate<? super Person> predicate) {
-        throw new AssertionError("This method should not be called.");
+        throw new AssertionError("This method (updateFilteredPersonList) should not be called.");
     }
 
     @Override
     public ObservableList<Activity> getFilteredActivityList() {
-        throw new AssertionError("This method should not be called.");
+        throw new AssertionError("This method (getFilteredActivityList) should not be called.");
     }
 
     @Override
     public void updateFilteredActivityList(Predicate<? super Activity> predicate) {
-        throw new AssertionError("This method should not be called.");
+        throw new AssertionError("This method (updateFilteredActivityList) should not be called.");
     }
 }

--- a/src/test/java/seedu/address/testutil/TypicalPersons.java
+++ b/src/test/java/seedu/address/testutil/TypicalPersons.java
@@ -45,6 +45,8 @@ public class TypicalPersons {
             .withEmail("lydia@example.com").withAddress("little tokyo").build();
     public static final Person GEORGE = new PersonBuilder().withName("George Best").withPhone("9482442")
             .withEmail("anna@example.com").withAddress("4th street").build();
+    public static final Person GEORGE_FIRSTNAME = new PersonBuilder().withName("George").withPhone("9482443")
+            .withEmail("george@example.com").withAddress("4th street").build();
 
     // Manually added
     public static final Person HOON = new PersonBuilder().withName("Hoon Meier").withPhone("8482424")


### PR DESCRIPTION
### Context
There was an edge case that happened when there were 2 contacts, with one contact's name being the substring of another.

Example:
Contact 1: George
Contact 2: George Yeoh

You will never be able to add Contact 1 in because when you search "George", it will always return 2 matches regardless.

Also, there is no validation to check if two person have the same name.

### Changes

- Added additional case for ActivityCommand, which now first checks if there is an exact match with the name. It will proceed to keyword based searching if there isn't.
- Added validation for Contact command, to check for duplicate names
- Added relevant tests
- Fixed broken ActivityCommand tests
- Update UserGuide and Developer Guide