### PR TITLE
Bugfix: Activity Command with empty string for participant prefix causes uncaught exception

### DIFF
--- a/src/main/java/seedu/address/commons/core/Messages.java
+++ b/src/main/java/seedu/address/commons/core/Messages.java
@@ -5,6 +5,7 @@ package seedu.address.commons.core;
  */
 public class Messages {
 
+    public static final String MESSAGE_EMPTY_SEARCH_TERM = "Search term for participant prefix cannot be empty.";
     public static final String MESSAGE_UNKNOWN_COMMAND = "Unknown command!";
     public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! \n%1$s";
     public static final String MESSAGE_INVALID_ACTIVITY_DISPLAY_INDEX = "The activity index provided is invalid!";

--- a/src/main/java/seedu/address/logic/parser/ActivityCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ActivityCommandParser.java
@@ -1,6 +1,7 @@
 package seedu.address.logic.parser;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.core.Messages.MESSAGE_EMPTY_SEARCH_TERM;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PARTICIPANT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TITLE;
@@ -35,6 +36,12 @@ public class ActivityCommandParser implements Parser<ActivityCommand> {
         Title title = ParserUtil.parseTitle(argMultimap.getValue(PREFIX_TITLE).get());
 
         List<String> participants = argMultimap.getAllValues(PREFIX_PARTICIPANT);
+
+        for (String participant : participants) {
+            if (participant.equals("")) {
+                throw new ParseException(MESSAGE_EMPTY_SEARCH_TERM);
+            }
+        }
 
         return new ActivityCommand(title, participants);
     }

--- a/src/test/java/seedu/address/logic/parser/ActivityCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/ActivityCommandParserTest.java
@@ -1,5 +1,6 @@
 package seedu.address.logic.parser;
 
+import static seedu.address.commons.core.Messages.MESSAGE_EMPTY_SEARCH_TERM;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.commands.ActivityCommand.MESSAGE_USAGE;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_ACTIVITY_TITLE;
@@ -32,6 +33,15 @@ public class ActivityCommandParserTest {
     public void parse_compulsoryFieldsMissing_failure() {
         // Title Missing
         assertParseFailure(parser, "", String.format(MESSAGE_INVALID_COMMAND_FORMAT, MESSAGE_USAGE));
+    }
+
+
+    @Test
+    public void parse_emptyParticipantPrefix_failure() {
+        // Participant prefix with empty value
+        String commandWithEmptyParticipantValue = " " + PREFIX_PARTICIPANT + " "
+                + PREFIX_TITLE + VALID_ACTIVITY_TITLE;
+        assertParseFailure(parser, commandWithEmptyParticipantValue, MESSAGE_EMPTY_SEARCH_TERM);
     }
 
     @Test


### PR DESCRIPTION
### Context
Apparently, when you run an activity command and include a participant prefix with empty value, the application will have an uncaught exception that prevents the command from being run, and shows no error. The following command could cause this bug previously:
`activity t/Test p/`
Turns out `NameContainsKeywordsPredicate` bugs out when you pass in an empty string.

### Change
- Fixed `ActivityCommandParser` to return a catchable exception, and show the appropriate warning message.
- Updated tests to take care of this bug.