### PR TITLE
Fix Activity list not updating when participants of an Activity changes

### DIFF
--- a/src/main/java/seedu/address/ui/ActivityListPanel.java
+++ b/src/main/java/seedu/address/ui/ActivityListPanel.java
@@ -28,6 +28,14 @@ public class ActivityListPanel extends UiPart<Region> {
     }
 
     /**
+     * Forces a refresh of the contents rendered by the {@code ListView} component of this
+     * {@ActivityListPanel}.
+     */
+    public void refreshView() {
+        this.listView.refresh();
+    }
+
+    /**
      * Custom {@code ListCell} that displays the graphics of an {@code Activity} entry with an {@code ActivityCard}.
      */
     class ListViewCell extends ListCell<Activity> {

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -156,6 +156,7 @@ public class MainWindow extends UiPart<Stage> {
 
         switch (newContextType) {
         case LIST_ACTIVITY:
+            activityListPanel.refreshView();
             contentContainer.getChildren().add(activityListPanel.getRoot());
             break;
         case LIST_CONTACT:


### PR DESCRIPTION
## Fix Activity list not updating when participants of an Activity changes
Bug description: When in the `VIEW_ACTIVITY` context, inviting or disinviting participants fails to prompt the list of activities (shown in `LIST_ACTIVITY` context) to re-render the respective cell, since the `Activity` instance is mutable and its properties are not wrapped with the `Observable<T>` JavaFX class.

### Changelog
- Fix the `ListView` of `Activity` cells in `ActivityListPanel` not re-rendering when a user changes the participants of one or more activities with the Invite or Disinvite command
   - Switching to a `LIST_ACTIVITY` context now unconditionally forces a refresh of the view rendered by the `ListView` in `ActivityListPanel`