### PR TITLE
Update find command to follow Context

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,7 +53,6 @@ tasks.withType(Test) {
     testLogging {
         // set options for log level LIFECYCLE
         events TestLogEvent.FAILED,
-               TestLogEvent.PASSED,
                TestLogEvent.SKIPPED,
                TestLogEvent.STANDARD_OUT
         exceptionFormat TestExceptionFormat.FULL
@@ -65,7 +64,6 @@ tasks.withType(Test) {
         debug {
             events TestLogEvent.STARTED,
                    TestLogEvent.FAILED,
-                   TestLogEvent.PASSED,
                    TestLogEvent.SKIPPED,
                    TestLogEvent.STANDARD_ERROR,
                    TestLogEvent.STANDARD_OUT

--- a/docs/UserGuide.adoc
+++ b/docs/UserGuide.adoc
@@ -220,13 +220,15 @@ Edits the phone number of the current contact in view to `999`. No changes are m
 Edits the title of the current activity in view to `BBQ`. No changes are made if an activity is not being viewed.
 // end::edit[]
 
-=== Finding contacts or activities (v1.4): `find`
+=== Finding contacts or activities: `find`
 
 Finds contacts or activities whose name or title respectively contain *any* of the given keywords.
 
 Format: `find KEYWORD ...`
 
 ****
+* Find command can only be used when viewing list of activities or contacts.
+* Find command will search for activities if used under list activity view. If used under list contact view, the find command will search for contacts.
 * The search is case insensitive. e.g `hans` will match `Hans`
 * The order of the keywords does not matter. e.g. `Hans Bo` will match `Bo Hans`
 * Only the name of contacts and title of activities are searched.
@@ -237,9 +239,8 @@ Format: `find KEYWORD ...`
 Examples:
 
 * `find John` +
-Returns contacts (e.g. `john` and `John Doe`) and activities (e.g. `John birthday party`).
-* `find Betsy Tim John` +
-Returns any contact or activity whose name or title contains the word `Betsy`, `Tim`, or `John`.
+If currently viewing list of contacts, returns contacts (e.g. `john` and `John Doe`).
+If currently viewing list of activities, returns activities (e.g `lunch with john`).
 
 === Deleting a contact, activity or expense (v1.4) : `delete`
 

--- a/src/main/java/seedu/address/commons/core/Messages.java
+++ b/src/main/java/seedu/address/commons/core/Messages.java
@@ -10,7 +10,6 @@ public class Messages {
     public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! \n%1$s";
     public static final String MESSAGE_INVALID_ACTIVITY_DISPLAY_INDEX = "The activity index provided is invalid!";
     public static final String MESSAGE_INVALID_PERSON_DISPLAY_INDEX = "The person index provided is invalid!";
-    public static final String MESSAGE_PERSONS_LISTED_OVERVIEW = "%1$d persons listed!";
+    public static final String MESSAGE_FOUND_BY_KEYWORD = "Found %d %s using the following search term: %s";
     public static final String MESSAGE_WARNING = "Warnings:\n%s";
-
 }

--- a/src/main/java/seedu/address/logic/commands/ActivityCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ActivityCommand.java
@@ -106,7 +106,6 @@ public class ActivityCommand extends Command {
         Context newContext = new Context(toAdd);
         model.addActivity(toAdd);
         model.setContext(newContext);
-        model.updateFilteredPersonList(x -> toAdd.getParticipantIds().contains(x.getPrimaryKey()));
         if (warningMessage.length() == 0) {
             return new CommandResult(String.format(MESSAGE_SUCCESS, toAdd, successMessage), newContext);
         } else {

--- a/src/main/java/seedu/address/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindCommand.java
@@ -31,12 +31,6 @@ public class FindCommand extends Command {
     public FindCommand(String[] keywords, String searchTerm) {
         this.keywords = keywords;
         this.searchTerm = searchTerm;
-        System.out.print("Keywords: ");
-        for (String a : keywords) {
-            System.out.print(a + ",");
-        }
-        System.out.println("");
-        System.out.println("searchTerm: " + searchTerm);
     }
 
     @Override
@@ -48,15 +42,14 @@ public class FindCommand extends Command {
             model.updateFilteredPersonList(new NameContainsKeywordsPredicate(Arrays.asList(keywords)));
             return new CommandResult(String.format(Messages.MESSAGE_FOUND_BY_KEYWORD,
                     model.getFilteredPersonList().size(),
-                    pluraize("contact", model.getFilteredPersonList().size()),
+                    pluralize("contact", model.getFilteredPersonList().size()),
                     searchTerm));
 
         case LIST_ACTIVITY:
             model.updateFilteredActivityList(new TitleContainsKeywordsPredicate(Arrays.asList(keywords)));
-
             return new CommandResult(String.format(Messages.MESSAGE_FOUND_BY_KEYWORD,
                     model.getFilteredActivityList().size(),
-                    pluraize("activity", model.getFilteredActivityList().size()),
+                    pluralize("activity", model.getFilteredActivityList().size()),
                     searchTerm));
         default:
             throw new CommandException(WARNING_INVALID_CONTEXT);
@@ -72,9 +65,9 @@ public class FindCommand extends Command {
     }
 
     /**
-     * Helper method that helps to pluraize given string, depending on the number given.
+     * Helper method that helps to pluralize given string, depending on the number given.
      */
-    private String pluraize(String input, int count) {
+    private String pluralize(String input, int count) {
         if (count <= 1) {
             return input;
         }

--- a/src/main/java/seedu/address/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindCommand.java
@@ -2,8 +2,13 @@ package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
 
+import java.util.Arrays;
+
 import seedu.address.commons.core.Messages;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.ContextType;
 import seedu.address.model.Model;
+import seedu.address.model.activity.TitleContainsKeywordsPredicate;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
 
 /**
@@ -18,25 +23,68 @@ public class FindCommand extends Command {
             + "the specified keywords (case-insensitive) and displays them as a list with index numbers.\n"
             + "Parameters: KEYWORD [MORE_KEYWORDS]...\n"
             + "Example: " + COMMAND_WORD + " alice bob charlie";
+    public static final String WARNING_INVALID_CONTEXT = "This command can only be used"
+            + "while viewing the list of activities/contacts.";
+    private final String searchTerm;
+    private final String[] keywords;
 
-    private final NameContainsKeywordsPredicate predicate;
-
-    public FindCommand(NameContainsKeywordsPredicate predicate) {
-        this.predicate = predicate;
+    public FindCommand(String[] keywords, String searchTerm) {
+        this.keywords = keywords;
+        this.searchTerm = searchTerm;
+        System.out.print("Keywords: ");
+        for (String a : keywords) {
+            System.out.print(a + ",");
+        }
+        System.out.println("");
+        System.out.println("searchTerm: " + searchTerm);
     }
 
     @Override
-    public CommandResult execute(Model model) {
+    public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
-        model.updateFilteredPersonList(predicate);
-        return new CommandResult(
-                String.format(Messages.MESSAGE_PERSONS_LISTED_OVERVIEW, model.getFilteredPersonList().size()));
+        ContextType type = model.getContext().getType();
+        switch (type) {
+        case LIST_CONTACT:
+            model.updateFilteredPersonList(new NameContainsKeywordsPredicate(Arrays.asList(keywords)));
+            return new CommandResult(String.format(Messages.MESSAGE_FOUND_BY_KEYWORD,
+                    model.getFilteredPersonList().size(),
+                    pluraize("contact", model.getFilteredPersonList().size()),
+                    searchTerm));
+
+        case LIST_ACTIVITY:
+            model.updateFilteredActivityList(new TitleContainsKeywordsPredicate(Arrays.asList(keywords)));
+
+            return new CommandResult(String.format(Messages.MESSAGE_FOUND_BY_KEYWORD,
+                    model.getFilteredActivityList().size(),
+                    pluraize("activity", model.getFilteredActivityList().size()),
+                    searchTerm));
+        default:
+            throw new CommandException(WARNING_INVALID_CONTEXT);
+        }
     }
 
     @Override
     public boolean equals(Object other) {
         return other == this // short circuit if same object
                 || (other instanceof FindCommand // instanceof handles nulls
-                && predicate.equals(((FindCommand) other).predicate)); // state check
+                && Arrays.equals(this.keywords, ((FindCommand) other).keywords)
+                && searchTerm.equals(((FindCommand) other).searchTerm));
+    }
+
+    /**
+     * Helper method that helps to pluraize given string, depending on the number given.
+     */
+    private String pluraize(String input, int count) {
+        if (count <= 1) {
+            return input;
+        }
+        switch (input) {
+        case "contact":
+            return "contacts";
+        case "activity":
+            return "activities";
+        default:
+            return "";
+        }
     }
 }

--- a/src/main/java/seedu/address/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindCommandParser.java
@@ -2,11 +2,10 @@ package seedu.address.logic.parser;
 
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 
-import java.util.Arrays;
+import java.util.ArrayList;
 
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
-import seedu.address.model.person.NameContainsKeywordsPredicate;
 
 /**
  * Parses input arguments and creates a new {@code FindCommand} object
@@ -26,8 +25,15 @@ public class FindCommandParser implements Parser<FindCommand> {
         }
 
         String[] nameKeywords = trimmedArgs.split("\\s+");
+        ArrayList<String> validKeywords = new ArrayList<String>();
+        for (String keyword : nameKeywords) {
+            if (keyword.length() == 0) {
+                continue;
+            }
+            validKeywords.add(keyword);
+        }
 
-        return new FindCommand(new NameContainsKeywordsPredicate(Arrays.asList(nameKeywords)));
+        return new FindCommand(validKeywords.toArray(new String[0]), trimmedArgs);
     }
 
 }

--- a/src/main/java/seedu/address/model/Context.java
+++ b/src/main/java/seedu/address/model/Context.java
@@ -21,7 +21,7 @@ public class Context {
      */
     public Context() {
         this.object = Optional.empty();
-        this.type = ContextType.MAIN;
+        this.type = ContextType.LIST_CONTACT;
     }
 
     private Context(ContextType type) {

--- a/src/main/java/seedu/address/model/ContextType.java
+++ b/src/main/java/seedu/address/model/ContextType.java
@@ -4,7 +4,6 @@ package seedu.address.model;
  * Represents the various types of contexts that can exist.
  */
 public enum ContextType {
-    MAIN,
     VIEW_CONTACT,
     VIEW_ACTIVITY,
     LIST_CONTACT,

--- a/src/main/java/seedu/address/model/activity/TitleContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/activity/TitleContainsKeywordsPredicate.java
@@ -1,0 +1,31 @@
+package seedu.address.model.activity;
+
+import java.util.List;
+import java.util.function.Predicate;
+
+import seedu.address.commons.util.StringUtil;
+
+/**
+ * Tests that a {@code Activity}'s {@code Title} matches any of the keywords given.
+ */
+public class TitleContainsKeywordsPredicate implements Predicate<Activity> {
+    private final List<String> keywords;
+
+    public TitleContainsKeywordsPredicate(List<String> keywords) {
+        this.keywords = keywords;
+    }
+
+    @Override
+    public boolean test(Activity activity) {
+        return keywords.stream()
+                .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(activity.getTitle().title, keyword));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof TitleContainsKeywordsPredicate // instanceof handles nulls
+                && keywords.equals(((TitleContainsKeywordsPredicate) other).keywords)); // state check
+    }
+
+}

--- a/src/test/java/seedu/address/logic/commands/ActivityCommandIntegrationTest.java
+++ b/src/test/java/seedu/address/logic/commands/ActivityCommandIntegrationTest.java
@@ -53,7 +53,6 @@ public class ActivityCommandIntegrationTest {
         Context newContext = new Context(validActivity);
         expectedModel.addActivity(validActivity);
         expectedModel.setContext(newContext);
-        expectedModel.updateFilteredPersonList(x -> validActivity.getParticipantIds().contains(x.getPrimaryKey()));
 
         assertCommandSuccess(new ActivityCommand(title, participants), model,
                 successMessage, expectedModel, newContext);
@@ -83,7 +82,7 @@ public class ActivityCommandIntegrationTest {
         Context newContext = new Context(validActivity);
         expectedModel.addActivity(validActivity);
         expectedModel.setContext(newContext);
-        expectedModel.updateFilteredPersonList(x -> validActivity.getParticipantIds().contains(x.getPrimaryKey()));
+
         assertCommandSuccess(new ActivityCommand(title, participants), model,
                 successMessage, expectedModel, newContext);
     }
@@ -112,7 +111,6 @@ public class ActivityCommandIntegrationTest {
         Context newContext = new Context(validActivity);
         expectedModel.addActivity(validActivity);
         expectedModel.setContext(newContext);
-        expectedModel.updateFilteredPersonList(x -> validActivity.getParticipantIds().contains(x.getPrimaryKey()));
 
         assertCommandSuccess(new ActivityCommand(title, participants), model,
                 successMessage, expectedModel, newContext);

--- a/src/test/java/seedu/address/logic/commands/FindCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/FindCommandTest.java
@@ -3,11 +3,9 @@ package seedu.address.logic.commands;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static seedu.address.commons.core.Messages.MESSAGE_PERSONS_LISTED_OVERVIEW;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.testutil.TypicalPersons.CARL;
-import static seedu.address.testutil.TypicalPersons.ELLE;
-import static seedu.address.testutil.TypicalPersons.FIONA;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 
 import java.util.Arrays;
@@ -15,37 +13,45 @@ import java.util.Collections;
 
 import org.junit.jupiter.api.Test;
 
-import seedu.address.model.ActivityBook;
+import seedu.address.commons.core.Messages;
+import seedu.address.model.Context;
 import seedu.address.model.InternalState;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
+import seedu.address.model.activity.TitleContainsKeywordsPredicate;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
+import seedu.address.testutil.TypicalActivities;
 
 /**
  * Contains integration tests (interaction with the Model) for {@code FindCommand}.
  */
 public class FindCommandTest {
     private Model model = new ModelManager(
-            getTypicalAddressBook(), new UserPrefs(), new InternalState(), new ActivityBook());
+            getTypicalAddressBook(),
+            new UserPrefs(),
+            new InternalState(),
+            TypicalActivities.getTypicalActivityBook());
     private Model expectedModel = new ModelManager(
-            getTypicalAddressBook(), new UserPrefs(), new InternalState(), new ActivityBook());
+            getTypicalAddressBook(),
+            new UserPrefs(),
+            new InternalState(),
+            TypicalActivities.getTypicalActivityBook());
 
     @Test
     public void equals() {
-        NameContainsKeywordsPredicate firstPredicate =
-                new NameContainsKeywordsPredicate(Collections.singletonList("first"));
-        NameContainsKeywordsPredicate secondPredicate =
-                new NameContainsKeywordsPredicate(Collections.singletonList("second"));
-
-        FindCommand findFirstCommand = new FindCommand(firstPredicate);
-        FindCommand findSecondCommand = new FindCommand(secondPredicate);
+        String firstSearchTerm = "Breakfast Lunch";
+        String secondSearchTerm = "Lunch Dinner";
+        String[] firstKeywords = firstSearchTerm.split("\\s+");
+        String[] secondKeywords = secondSearchTerm.split("\\s+");
+        FindCommand findFirstCommand = new FindCommand(firstKeywords, firstSearchTerm);
+        FindCommand findSecondCommand = new FindCommand(secondKeywords, secondSearchTerm);
 
         // same object -> returns true
         assertTrue(findFirstCommand.equals(findFirstCommand));
 
         // same values -> returns true
-        FindCommand findFirstCommandCopy = new FindCommand(firstPredicate);
+        FindCommand findFirstCommandCopy = new FindCommand(firstKeywords, firstSearchTerm);
         assertTrue(findFirstCommand.equals(findFirstCommandCopy));
 
         // different types -> returns false
@@ -59,23 +65,106 @@ public class FindCommandTest {
     }
 
     @Test
-    public void execute_zeroKeywords_noPersonFound() {
-        String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 0);
-        NameContainsKeywordsPredicate predicate = preparePredicate(" ");
-        FindCommand command = new FindCommand(predicate);
+    public void execute_viewPersonContext_throwError() {
+        String expectedMessage = FindCommand.WARNING_INVALID_CONTEXT;
+        String searchTerm = "Test 123";
+        String[] keywords = splitSearchTerm(searchTerm);
+        FindCommand command = new FindCommand(keywords, searchTerm);
+        expectedModel.setContext(new Context(TypicalActivities.BREAKFAST));
+        model.setContext(new Context(TypicalActivities.BREAKFAST));
+        assertCommandFailure(command, model, expectedMessage);
+        // There should be no change
+        assertEquals(model.getFilteredPersonList(), expectedModel.getFilteredPersonList());
+    }
+
+    @Test
+    public void execute_viewActivityContext_throwError() {
+        String expectedMessage = FindCommand.WARNING_INVALID_CONTEXT;
+        String searchTerm = "Test 123";
+        String[] keywords = splitSearchTerm(searchTerm);
+        FindCommand command = new FindCommand(keywords, searchTerm);
+        expectedModel.setContext(new Context(CARL));
+        model.setContext(new Context(CARL));
+        assertCommandFailure(command, model, expectedMessage);
+        // There should be no change
+        assertEquals(model.getFilteredPersonList(), expectedModel.getFilteredPersonList());
+    }
+
+    // Tests for list contacts context
+    @Test
+    public void executeContactFind_noMatchingKeyword_noContactFound() {
+        String searchTerm = "test testing";
+        String[] keywords = splitSearchTerm(searchTerm);
+        NameContainsKeywordsPredicate predicate = preparePredicate(searchTerm);
+        String expectedMessage = String.format(Messages.MESSAGE_FOUND_BY_KEYWORD,
+                0, "contact", searchTerm);
         expectedModel.updateFilteredPersonList(predicate);
+        expectedModel.setContext(Context.newListContactContext());
+        model.setContext(Context.newListContactContext());
+
+        FindCommand command = new FindCommand(keywords, searchTerm);
+
         assertCommandSuccess(command, model, expectedMessage, expectedModel);
         assertEquals(Collections.emptyList(), model.getFilteredPersonList());
     }
 
     @Test
-    public void execute_multipleKeywords_multiplePersonsFound() {
-        String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 3);
-        NameContainsKeywordsPredicate predicate = preparePredicate("Kurz Elle Kunz");
-        FindCommand command = new FindCommand(predicate);
+    public void executeContactFind_multipleKeywords_multipleContactsFound() {
+        String searchTerm = "benson pauline";
+        String[] keywords = splitSearchTerm(searchTerm);
+        NameContainsKeywordsPredicate predicate = preparePredicate(searchTerm);
+        String expectedMessage = String.format(Messages.MESSAGE_FOUND_BY_KEYWORD,
+                2, "contacts", searchTerm);
         expectedModel.updateFilteredPersonList(predicate);
+        expectedModel.setContext(Context.newListContactContext());
+        model.setContext(Context.newListContactContext());
+
+        FindCommand command = new FindCommand(keywords, searchTerm);
+
         assertCommandSuccess(command, model, expectedMessage, expectedModel);
-        assertEquals(Arrays.asList(CARL, ELLE, FIONA), model.getFilteredPersonList());
+        assertEquals(expectedModel.getFilteredPersonList(), model.getFilteredPersonList());
+    }
+
+    // Tests for list activities context
+    @Test
+    public void executeActivityFind_noMatchingKeyword_noActivityFound() {
+        String searchTerm = "test testing";
+        String[] keywords = splitSearchTerm(searchTerm);
+        TitleContainsKeywordsPredicate predicate = prepareTitlePredicate(searchTerm);
+        String expectedMessage = String.format(Messages.MESSAGE_FOUND_BY_KEYWORD,
+                0, "activity", searchTerm);
+        expectedModel.updateFilteredActivityList(predicate);
+        expectedModel.setContext(Context.newListActivityContext());
+        model.setContext(Context.newListActivityContext());
+
+        FindCommand command = new FindCommand(keywords, searchTerm);
+
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+        assertEquals(Collections.emptyList(), model.getFilteredActivityList());
+    }
+
+    @Test
+    public void executeActivityFind_multipleKeywords_multipleActivitiesFound() {
+        String searchTerm = "breakfast lunch";
+        String[] keywords = splitSearchTerm(searchTerm);
+        TitleContainsKeywordsPredicate predicate = prepareTitlePredicate(searchTerm);
+        String expectedMessage = String.format(Messages.MESSAGE_FOUND_BY_KEYWORD,
+                2, "activities", searchTerm);
+        expectedModel.updateFilteredActivityList(predicate);
+        expectedModel.setContext(Context.newListActivityContext());
+        model.setContext(Context.newListActivityContext());
+
+        FindCommand command = new FindCommand(keywords, searchTerm);
+
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+        assertEquals(expectedModel.getFilteredActivityList(), model.getFilteredActivityList());
+    }
+
+    /**
+     * Helper method used to parse the search term into keywords.
+     */
+    private String[] splitSearchTerm(String searchTerm) {
+        return searchTerm.split("\\s+");
     }
 
     /**
@@ -83,5 +172,12 @@ public class FindCommandTest {
      */
     private NameContainsKeywordsPredicate preparePredicate(String userInput) {
         return new NameContainsKeywordsPredicate(Arrays.asList(userInput.split("\\s+")));
+    }
+
+    /**
+     * Parses {@code userInput} into a {@code TitleContainsKeywordsPredicate}.
+     */
+    private TitleContainsKeywordsPredicate prepareTitlePredicate(String userInput) {
+        return new TitleContainsKeywordsPredicate(Arrays.asList(userInput.split("\\s+")));
     }
 }

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -8,10 +8,6 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_TITLE;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST;
 
-import java.util.Arrays;
-import java.util.List;
-import java.util.stream.Collectors;
-
 import org.junit.jupiter.api.Test;
 
 import seedu.address.logic.commands.AddCommand;
@@ -25,7 +21,6 @@ import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.activity.Activity;
-import seedu.address.model.person.NameContainsKeywordsPredicate;
 import seedu.address.model.person.Person;
 import seedu.address.testutil.ActivityBuilder;
 import seedu.address.testutil.EditActivityDescriptorBuilder;
@@ -80,10 +75,11 @@ public class AddressBookParserTest {
 
     @Test
     public void parseCommand_find() throws Exception {
-        List<String> keywords = Arrays.asList("foo", "bar", "baz");
+        String searchTerm = "foo bar baz";
+        String[] keywords = searchTerm.split("\\s+");
         FindCommand command = (FindCommand) parser.parseCommand(
-                FindCommand.COMMAND_WORD + " " + keywords.stream().collect(Collectors.joining(" ")));
-        assertEquals(new FindCommand(new NameContainsKeywordsPredicate(keywords)), command);
+                FindCommand.COMMAND_WORD + " " + searchTerm);
+        assertEquals(new FindCommand(keywords, searchTerm), command);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
@@ -4,12 +4,9 @@ import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
 
-import java.util.Arrays;
-
 import org.junit.jupiter.api.Test;
 
 import seedu.address.logic.commands.FindCommand;
-import seedu.address.model.person.NameContainsKeywordsPredicate;
 
 public class FindCommandParserTest {
 
@@ -24,11 +21,16 @@ public class FindCommandParserTest {
     public void parse_validArgs_returnsFindCommand() {
         // no leading and trailing whitespaces
         FindCommand expectedFindCommand =
-                new FindCommand(new NameContainsKeywordsPredicate(Arrays.asList("Alice", "Bob")));
+                new FindCommand("Alice Bob".split("\\s+"), "Alice Bob");
         assertParseSuccess(parser, "Alice Bob", expectedFindCommand);
+    }
 
-        // multiple whitespaces between keywords
-        assertParseSuccess(parser, " \n Alice \n \t Bob  \t", expectedFindCommand);
+    @Test
+    public void parse_validArgsWithWhiteSpace_trimsWhiteSpace() {
+        String userInput = " \n Alice \n \t Bob  \t";
+        FindCommand expectedFindCommand =
+                new FindCommand(new String[] {"Alice", "Bob"}, "Alice Bob");
+        assertParseSuccess(parser, "Alice Bob", expectedFindCommand);
     }
 
 }

--- a/src/test/java/seedu/address/model/ContextTest.java
+++ b/src/test/java/seedu/address/model/ContextTest.java
@@ -35,7 +35,7 @@ public class ContextTest {
 
     @Test
     public void getType_allTypes_returnsCorrectType() {
-        assertEquals(new Context().getType(), ContextType.MAIN);
+        assertEquals(new Context().getType(), ContextType.LIST_CONTACT);
         assertEquals(new Context(TypicalPersons.ALICE).getType(), ContextType.VIEW_CONTACT);
         assertEquals(new Context(TypicalActivities.BREAKFAST).getType(), ContextType.VIEW_ACTIVITY);
         assertEquals(Context.newListActivityContext().getType(), ContextType.LIST_ACTIVITY);

--- a/src/test/java/seedu/address/model/activity/TitleContainsKeywordsPredicateTest.java
+++ b/src/test/java/seedu/address/model/activity/TitleContainsKeywordsPredicateTest.java
@@ -1,0 +1,77 @@
+package seedu.address.model.activity;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.testutil.ActivityBuilder;
+import seedu.address.testutil.TypicalActivities;
+
+public class TitleContainsKeywordsPredicateTest {
+
+    @Test
+    public void equals() {
+        List<String> firstPredicateKeywordList = Collections.singletonList("first");
+        List<String> secondPredicateKeywordList = Arrays.asList("first", "second");
+
+        TitleContainsKeywordsPredicate firstPredicate = new TitleContainsKeywordsPredicate(firstPredicateKeywordList);
+        TitleContainsKeywordsPredicate secondPredicate = new TitleContainsKeywordsPredicate(secondPredicateKeywordList);
+
+        // same object -> returns true
+        assertTrue(firstPredicate.equals(firstPredicate));
+
+        // same values -> returns true
+        TitleContainsKeywordsPredicate firstPredicateCopy = new TitleContainsKeywordsPredicate(
+                firstPredicateKeywordList);
+        assertTrue(firstPredicate.equals(firstPredicateCopy));
+
+        // different types -> returns false
+        assertFalse(firstPredicate.equals(1));
+
+        // null -> returns false
+        assertFalse(firstPredicate.equals(null));
+
+        // different keywords -> returns false
+        assertFalse(firstPredicate.equals(secondPredicate));
+    }
+
+    @Test
+    public void test_titleContainsKeywords_returnsTrue() {
+        // One keyword
+        TitleContainsKeywordsPredicate predicate = new TitleContainsKeywordsPredicate(
+                Collections.singletonList("Breakfast"));
+        assertTrue(predicate.test(new ActivityBuilder().withTitle("Breakfast with Keven").build()));
+
+        // Multiple keywords
+        predicate = new TitleContainsKeywordsPredicate(Arrays.asList("Breakfast", "Keven"));
+        assertTrue(predicate.test(new ActivityBuilder().withTitle("Breakfast with Keven").build()));
+
+        // Only one matching keyword
+        predicate = new TitleContainsKeywordsPredicate(Arrays.asList("Keven", "Lunch"));
+        assertTrue(predicate.test(new ActivityBuilder().withTitle("Breakfast with Keven").build()));
+
+        // Mixed-case keywords
+        predicate = new TitleContainsKeywordsPredicate(Arrays.asList("kEvEn", "bReaKfAsT"));
+        assertTrue(predicate.test(new ActivityBuilder().withTitle("Breakfast with Keven").build()));
+    }
+
+    @Test
+    public void test_titleDoesNotContainKeywords_returnsFalse() {
+        // Zero keywords
+        TitleContainsKeywordsPredicate predicate = new TitleContainsKeywordsPredicate(Collections.emptyList());
+        assertFalse(predicate.test(new ActivityBuilder().withTitle("Breakfast with Keven").build()));
+
+        // Non-matching keyword
+        predicate = new TitleContainsKeywordsPredicate(Arrays.asList("John"));
+        assertFalse(predicate.test(new ActivityBuilder().withTitle("Breakfast with Keven").build()));
+
+        // Keywords match participant name, but does not match title
+        predicate = new TitleContainsKeywordsPredicate(Arrays.asList("Alice"));
+        assertFalse(predicate.test(TypicalActivities.BREAKFAST));
+    }
+}


### PR DESCRIPTION
# Issue
Previously, the default find command did not follow context and always searched for contacts. With the context feature being added in, it is important to make the command change behaviour depending on the current context.

# Changes
- Updated find command to search for contacts when in `LIST_CONTACT` context
- Updated find command to search for activities when in `LIST_ACTIVITY` context
- Gradle now only displays results for failed tests
- Updated and added necessary tests
- Bugfix: Fixed an issue where creating an activity updated the `filteredPersonList`.